### PR TITLE
Fix the dictionary encoding example

### DIFF
--- a/draft-specification.md
+++ b/draft-specification.md
@@ -129,17 +129,18 @@ The following JSON:
 {
     "name": "Alice",
     "age": 30,
-    "isAlive": true
+    "isAlive": true,
+    "attributes": {}
 }
 ```
 
 would serialize to:
 
 ```syrup
-{3:age30+4:name5:Alice7:isAlivet}
+{10"attributes{}3"age30+4"name5"Alice7"isAlivet}
 ```
 
-Note that the keys occur in the following order: `age`, `name`, and `isAlive` due to sorting.
+Note that due to sorting by key encoding, keys occur in the following order: `attributes`, `age`, `name`, `isAlive`.
 
 ### Sequences
 


### PR DESCRIPTION
* Encode strings like `<decimal length>"<UTF-8 octets>`.
* Add a long-string key to show that the decimal length affects sort order (e.g., a 10-character string key sorts before any non-empty shorter string key because "10" sorts before "1" through "9").

(please confirm both before merging)