### PR TITLE
Fix the record encoding example

### DIFF
--- a/draft-specification.md
+++ b/draft-specification.md
@@ -169,7 +169,7 @@ A record with the label being the symbol `person` followed by three fields with 
 would be serialized as:
 
 ```syrup
-<6:person5:Alice30+t>
+<6'person5"Alice30+t>
 ```
 
 ### Sets


### PR DESCRIPTION
* Encode symbols like `<decimal length>'<UTF-8 octets>`.
* Encode strings like `<decimal length>"<UTF-8 octets>`.