### PR TITLE
Expand the set encoding example

### DIFF
--- a/draft-specification.md
+++ b/draft-specification.md
@@ -180,10 +180,10 @@ Sets are considered to be unordered data structures, containing unique values. L
 
 #### Example
 
-The set with the members `3`, `2`, and `1` (all positive integers) would be serialized as:
+The set with the members `3`, `2`, `1`, and `10` (all positive integers) would be serialized as:
 
 ```syrup
-#1+2+3+$
+#1+10+2+3+$
 ```
 
 ## [Sorting Algorithm](#sorting-algorithm)


### PR DESCRIPTION
Add an element to show that sorting applies to serialized values (e.g., "1+" precedes "10+" because 0x2B "+" is less than 0x30 "0" at index 1, and "10+" precedes "2+" because 0x31 "1" is less than 0x32 "2" at index 0).